### PR TITLE
Sanitise filenames that aren't sensible

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -57,7 +57,7 @@ func NewClientCache(id, secret, code string, cache oauth.Cache) (*http.Client, e
 			// Get an authorization code from the data provider.
 			// ("Please ask the user if I can access this resource.")
 			url := transport.Config.AuthCodeURL("picago")
-			fmt.Println("Visit this URL to get a code, then run again with code=YOUR_CODE\n")
+			fmt.Println("Visit this URL to allow access to your Picasa data:\n")
 			fmt.Println(url)
 
 			srv := &http.Server{Handler: NewAuthorizeHandler(transport, donech)}

--- a/get.go
+++ b/get.go
@@ -254,6 +254,9 @@ func (e *Entry) photo() (p Photo, err error) {
 		Latitude:    lat,
 		Longitude:   long,
 	}
+	// Sanitise Filename in case of slashes in filename (sometimes present in google photos)
+	p.Filename = strings.Split(p.Filename, "/")[len(strings.Split(p.Filename, "/"))-1]
+
 	for _, link := range e.Links {
 		if link.Rel == "alternate" && link.Type == "text/html" {
 			p.PageURL = link.URL


### PR DESCRIPTION
In Google Photos, some images have weird filenames such as "/data/data/com.google.android.apps.schemer/cache/photo-1354144506598". This causes picago to fail so instead of just erroring out, it now takes the last part of the filepath as the filename. I'm new to Go programming but hopefully this simple change makes sense.

Oh and I'm also new to github and accidentally forked from the wrong repository. Hope that isn't a problem!

Cheers.
